### PR TITLE
Add shadcn styles via Tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Diet App
 
 Simple example React Native (Expo) app to manage diets. Uses TypeScript and works on web.
+Now styled with [Shadcn UI](https://ui.shadcn.com/) components via NativeWind and Tailwind CSS.
 
 ## Features
 - Store diet information in AsyncStorage so data is preserved between sessions.
@@ -15,5 +16,7 @@ Install dependencies and start the development server:
 npm install
 npm start
 ```
+
+Tailwind CSS is configured with NativeWind so no extra build steps are required.
 
 The app uses Expo so you can run it on Android, iOS or web.

--- a/babel.config.js
+++ b/babel.config.js
@@ -2,5 +2,6 @@ module.exports = function(api) {
   api.cache(true);
   return {
     presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
   };
 };

--- a/package.json
+++ b/package.json
@@ -17,11 +17,17 @@
     "react-native": "0.72.3",
     "react-native-web": "~0.19.9",
     "@react-native-async-storage/async-storage": "~1.17.11",
-    "react-native-uuid": "^2.0.1"
+    "react-native-uuid": "^2.0.1",
+    "nativewind": "^2.0.11",
+    "class-variance-authority": "^0.6.1",
+    "clsx": "^2.0.0",
+    "tailwind-merge": "^1.1.2",
+    "tailwindcss-animate": "^1.0.5"
   },
   "devDependencies": {
     "@types/react": "~18.0.27",
     "@types/react-native": "~0.72.3",
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "tailwindcss": "^3.3.2"
   }
 }

--- a/src/components/DayPlanView.tsx
+++ b/src/components/DayPlanView.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
 import { DayPlan } from '../types/diet';
 import MealList from './MealList';
 
@@ -9,23 +9,11 @@ interface Props {
 
 export default function DayPlanView({ plan }: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.date}>{plan.date}</Text>
+    <View className="p-4 border-b border-gray-300 dark:border-gray-600">
+      <Text className="text-xl font-bold mb-2 text-black dark:text-white">{plan.date}</Text>
       {plan.meals.map(meal => (
         <MealList key={meal.id} meal={meal} />
       ))}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    padding: 16,
-    borderBottomColor: '#ccc',
-    borderBottomWidth: StyleSheet.hairlineWidth,
-  },
-  date: {
-    fontSize: 20,
-    fontWeight: 'bold',
-  },
-});

--- a/src/components/MealItem.tsx
+++ b/src/components/MealItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
 import { MealItem as MealItemType } from '../types/diet';
 
 interface Props {
@@ -8,17 +8,8 @@ interface Props {
 
 export default function MealItem({ item }: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.text}>{item.name} {item.quantity ? `- ${item.quantity}` : ''}</Text>
+    <View className="py-1">
+      <Text className="text-base text-black dark:text-white">{item.name} {item.quantity ? `- ${item.quantity}` : ''}</Text>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    paddingVertical: 4,
-  },
-  text: {
-    fontSize: 16,
-  },
-});

--- a/src/components/MealList.tsx
+++ b/src/components/MealList.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { View, Text, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
 import { Meal } from '../types/diet';
 import MealItem from './MealItem';
 
@@ -9,22 +9,11 @@ interface Props {
 
 export default function MealList({ meal }: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>{meal.title}</Text>
+    <View className="my-2">
+      <Text className="text-lg font-bold mb-1 text-black dark:text-white">{meal.title}</Text>
       {meal.items.map(item => (
         <MealItem key={item.id} item={item} />
       ))}
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    marginVertical: 8,
-  },
-  title: {
-    fontSize: 18,
-    fontWeight: 'bold',
-    marginBottom: 4,
-  },
-});

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Pressable, Text } from 'react-native'
+import { cva, type VariantProps } from 'class-variance-authority'
+import { cn } from '../../lib/utils'
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center rounded-md text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:opacity-50 disabled:pointer-events-none ring-offset-background',
+  {
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'underline-offset-4 hover:underline text-primary',
+      },
+      size: {
+        default: 'h-10 py-2 px-4',
+        sm: 'h-9 px-3 rounded-md',
+        lg: 'h-11 px-8 rounded-md',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  }
+)
+
+export interface ButtonProps extends React.ComponentPropsWithoutRef<typeof Pressable>, VariantProps<typeof buttonVariants> {
+  text: string
+}
+
+export const Button = React.forwardRef<Pressable, ButtonProps>(({ className, variant, size, text, ...props }, ref) => (
+  <Pressable ref={ref} className={cn(buttonVariants({ variant, size }), className)} {...props}>
+    <Text className="text-center text-base font-medium text-white">{text}</Text>
+  </Pressable>
+))
+Button.displayName = 'Button'

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx'
+import { twMerge } from 'tailwind-merge'
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs))
+}

--- a/src/screens/EditDietScreen.tsx
+++ b/src/screens/EditDietScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet, FlatList } from 'react-native';
+import { View, Text, TextInput, StyleSheet, FlatList } from 'react-native';
+import { Button } from '../components/ui/button';
 import { Diet, DayPlan, Meal, MealItem } from '../types/diet';
 import uuid from 'react-native-uuid';
 
@@ -57,15 +58,15 @@ export default function EditDietScreen({ diet, onSave, onBack }: Props) {
         value={itemName}
         onChangeText={setItemName}
       />
-      <Button title="Add Item" onPress={addItem} />
+      <Button text="Add Item" onPress={addItem} className="mt-2" />
       <FlatList
         data={items}
         keyExtractor={item => item.id}
         renderItem={({ item }) => <Text>{item.name}</Text>}
       />
-      <Button title="Add Meal" onPress={addMeal} />
-      <Button title="Save Day" onPress={savePlan} />
-      <Button title="Back" onPress={onBack} />
+      <Button text="Add Meal" onPress={addMeal} className="mt-2" />
+      <Button text="Save Day" onPress={savePlan} className="mt-2" />
+      <Button text="Back" onPress={onBack} className="mt-2" />
     </View>
   );
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Text } from 'react-native';
+import { Button } from '../components/ui/button';
 import { Diet } from '../types/diet';
 import DietList from '../components/DietList';
 
@@ -11,31 +12,13 @@ interface Props {
 
 export default function HomeScreen({ diet, onEdit, onImport }: Props) {
   return (
-    <View style={styles.container}>
-      <Text style={styles.title}>My Diet</Text>
+    <View className="flex-1 pt-10 bg-white dark:bg-black">
+      <Text className="text-2xl font-bold mx-4 mb-4 text-black dark:text-white">My Diet</Text>
       <DietList diet={diet} />
-      <View style={styles.buttons}>
-        <Button title="Edit Diet" onPress={onEdit} />
-        <Button title="Import" onPress={onImport} />
+      <View className="flex-row justify-around p-4">
+        <Button text="Edit Diet" onPress={onEdit} />
+        <Button text="Import" onPress={onImport} className="ml-2" />
       </View>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    paddingTop: 40,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginHorizontal: 16,
-    marginBottom: 16,
-  },
-  buttons: {
-    flexDirection: 'row',
-    justifyContent: 'space-around',
-    padding: 16,
-  },
-});

--- a/src/screens/ImportScreen.tsx
+++ b/src/screens/ImportScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
-import { View, Text, TextInput, Button, StyleSheet, Alert } from 'react-native';
+import { View, Text, TextInput, StyleSheet, Alert } from 'react-native';
+import { Button } from '../components/ui/button';
 import { Diet } from '../types/diet';
 import { sampleDiet } from '../utils/sampleDiet';
 
@@ -36,9 +37,9 @@ export default function ImportScreen({ onImport, onBack }: Props) {
         placeholder="{...}"
       />
       <View style={styles.buttons}>
-        <Button title="Import" onPress={handleImport} />
-        <Button title="Load Sample" onPress={handleLoadSample} />
-        <Button title="Back" onPress={onBack} />
+        <Button text="Import" onPress={handleImport} />
+        <Button text="Load Sample" onPress={handleLoadSample} className="mx-2" />
+        <Button text="Back" onPress={onBack} />
       </View>
     </View>
   );

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    "./App.{js,jsx,ts,tsx}",
+    "./src/**/*.{js,jsx,ts,tsx}"
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [require("tailwindcss-animate")],
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "isolatedModules": true,
     "noEmit": true,
     "jsx": "react",
-    "types": ["node"]
+    "types": ["node", "nativewind/types"]
   },
   "include": ["**/*.ts", "**/*.tsx"],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## Summary
- install tailwind, nativewind and shadcn dependencies
- configure babel and tsconfig for nativewind
- add tailwind configuration with tailwindcss-animate plugin
- create reusable Button component from shadcn
- restyle screens and components with Tailwind classes
- document new setup in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688cfb399e74832a9c7a7b1979c9f417